### PR TITLE
"Bump" unit threaded version

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -15,7 +15,7 @@
         "dub run --compiler=$$DC unit-threaded -c gen_ut_main -- -f bin/ut.d"
       ],
       "dependencies": {
-        "unit-threaded": "~>0"
+        "unit-threaded": "*"
       },
       "excludedSourceFiles": [
         "src/main.d"


### PR DESCRIPTION
When your application also uses unit-thread with a current version, you get the following warning:

`Warning Selected package unit-threaded@2.2.3 does not match the dependency specification ~>0 in package cachetools. Need to "dub upgrade"?`

This disables it.

Note that the tests are still failing, but this unrelated to the unit-threaded version.