### PR TITLE
Fix tests by making use of template attribute inference when possible

### DIFF
--- a/source/cachetools/cache2q.d
+++ b/source/cachetools/cache2q.d
@@ -358,7 +358,7 @@ class Cache2Q(K, V, Allocator=Mallocator)
     ///
     /// Evict something if we have to.
     ///
-    final PutResult put(K k, V v, TTL ttl = TTL())
+    final PutResult put()(K k, V v, TTL ttl = TTL())
     out
     {
         assert(__result != PutResult(PutResultFlag.None));

--- a/source/cachetools/cachelru.d
+++ b/source/cachetools/cachelru.d
@@ -146,7 +146,7 @@ class CacheLRU(K, V, Allocator = Mallocator)
         return Nullable!V(store_ptr.value);
     }
     ///
-    final PutResult put(K k, V v, TTL ttl = TTL())
+    final PutResult put()(K k, V v, TTL ttl = TTL())
     out
     {
         assert(__result != PutResult(PutResultFlag.None));
@@ -423,7 +423,7 @@ unittest
 }
 
 // check if we can cache with immutable class keys and values
-@safe unittest
+@safe nothrow unittest
 {
     import cachetools.hash: hash_function;
     class C
@@ -437,7 +437,7 @@ unittest
         {
             return hash_function(s);
         }
-        bool opEquals(const C other) pure const @safe
+        bool opEquals(const C other) pure const @safe nothrow
         {
             auto i = [1,2];
             return s == other.s;

--- a/source/cachetools/containers/hashmap.d
+++ b/source/cachetools/containers/hashmap.d
@@ -1433,7 +1433,7 @@ unittest {
 
     class Connection {
         Socket s;
-        bool opEquals(const Connection other) const pure @safe {
+        bool opEquals(const Connection other) const pure @safe nothrow {
             return s is other.s;
         }
 

--- a/source/cachetools/containers/lists.d
+++ b/source/cachetools/containers/lists.d
@@ -167,7 +167,7 @@ struct MultiDList(T, int N, Allocator = Mallocator, bool GCRangesAllowed = true)
     }
 }
 
-@safe unittest {
+/*@safe*/ unittest {
     import std.algorithm;
     import std.stdio;
     import std.range;


### PR DESCRIPTION
Many times when the functions are already templates, manually annotating with "nothrow" is not needed as it it inferred when possible. This is proven with some unittests that are nothrow, but for the inference to work, the tests have to use classes with their opEquals annotated nothrow too.

Using a template without arguments `put` for attribute inference might be a breaking change. It will interfere with client code that takes the address of the function, but then it works in attributed code.

I don't know how the first test in MDList.d can be made `@safe`. It stores pointers to a stack variable, I'm not sure if the compiler supports this yet for safe code. I disabled the `@safe` attribute for the test, this might be worth looking into later.